### PR TITLE
Added g:vinegar_ignore for vinegar specific ignore

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -6,6 +6,10 @@ if exists("g:loaded_vinegar") || v:version < 700 || &cp
 endif
 let g:loaded_vinegar = 1
 
+if !exists("g:vinegar_ignore")
+  let g:vinegar_ignore = ""
+endif
+
 function! s:fnameescape(file) abort
   if exists('*fnameescape')
     return fnameescape(a:file)
@@ -16,7 +20,8 @@ endfunction
 
 let g:netrw_sort_sequence = '[\/]$,*,\%(' . join(map(split(&suffixes, ','), 'escape(v:val, ".*$~")'), '\|') . '\)[*@]\=$'
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
-let g:netrw_list_hide = join(map(split(&wildignore, ','), '"^".' . s:escape . '. "$"'), ',') . ',^\.\.\=/\=$'
+let s:hide_list = split(&wildignore, ',') + split(g:vinegar_ignore, ',')
+let g:netrw_list_hide = join(map(s:hide_list, '"^".' . s:escape . '. "$"'), ',') . ',^\.\.\=/\=$'
 let g:netrw_banner = 0
 let s:netrw_up = ''
 


### PR DESCRIPTION
Vinegar uses g:netrw_list_hide to hide files in netrw but makes netrw
specific hiding impossible. To fix this g:vinegar_ignore was added that
takes a comma delimited list like wildignore that will only apply to
vinegar/netrw.
