### PR TITLE
add netrw toggle mapping

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -89,3 +89,31 @@ function! s:setup_vinegar() abort
   exe 'syn match netrwSuffixes =\%(\S\+ \)*\S\+\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)[*@]\=\S\@!='
   hi def link netrwSuffixes SpecialKey
 endfunction
+
+
+nnoremap <silent> <Plug>ToggleVinegar :call <SID>ToggleVinegar()<CR>
+
+function! s:StartVinegar()
+  exec "1wincmd w"
+  exec "normal \<Plug>VinegarVerticalSplitUp"
+  vertical resize -10
+  let t:expl_buf_num = bufnr("%")
+endfunction
+
+function! s:KillIfNetrwBuffer()
+  if &filetype ==# "netrw"
+    wincmd c
+    return 1
+  else
+    return 0
+  endif
+endfunction
+
+function! s:ToggleVinegar()
+  let NumberOfNetrwWindows = 0
+  windo let NumberOfNetrwWindows += s:KillIfNetrwBuffer()
+  if NumberOfNetrwWindows == 0
+     call s:StartVinegar()
+  endif
+endfunction
+


### PR DESCRIPTION
How about the following mapping <Plug>ToggleVinegar ? 

It allows to toggle netrw in a vertical split and works independent of the way netrw was invoked in the first place. It is admittedly brutal because it closes all open panes. But if it is to be a toggle, there's no way around it.
