### PR TITLE
Option to cancel netrw/vinegar without losing split

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -69,6 +69,16 @@ function! s:escaped(first, last) abort
   return join(map(files, 'fnamemodify(b:netrw_curdir."/".v:val,":~:.")'), ' ')
 endfunction
 
+function! s:graceful_exit()
+    let netrw_bufnum = bufnr("%")
+    try
+        execute ":b#"
+    catch /E85:/
+    endtry
+    " execute ":bwipe"
+    execute ":bwipe " . string(netrw_bufnum)
+endfunction
+
 function! s:setup_vinegar() abort
   if empty(s:netrw_up)
     " save netrw mapping
@@ -88,4 +98,7 @@ function! s:setup_vinegar() abort
   nnoremap <buffer> <silent> cl :exe 'keepjumps lcd '.<SID>fnameescape(b:netrw_curdir)<CR>
   exe 'syn match netrwSuffixes =\%(\S\+ \)*\S\+\%('.join(map(split(&suffixes, ','), s:escape), '\|') . '\)[*@]\=\S\@!='
   hi def link netrwSuffixes SpecialKey
+  if !exists("g:vinegar_preserve_splits_on_close") || g:vinegar_preserve_splits_on_close
+    nnoremap <buffer> <silent> <ESC> :call <SID>graceful_exit()<CR>
+  endif
 endfunction


### PR DESCRIPTION
Sometimes, I cancel the netrw session by hitting '`ESC`'. That is, I invoke `netrw` (hitting '-' with the Vinegar wrapper), and then exit without selecting a file. If my Vim session has splits, this action results in the active split being lost. For example, if the vim screen is split into two windows, by default hitting '-' and then '`ESC`' results in only a single window remaining (the window that was _not_ the active window). I find this behavior a little disconcerting. To address this, I added the option of replacing the previous buffer in the split before deleting the netrw buffer. 
