### PR TITLE
Allow opening netrw in new tab

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -29,6 +29,7 @@ if empty(maparg('-', 'n'))
   nmap - <Plug>VinegarUp
 endif
 
+nnoremap <silent> <Plug>VinegarTabUp :call <SID>opendir('tabedit')<CR>
 nnoremap <silent> <Plug>VinegarSplitUp :call <SID>opendir('split')<CR>
 nnoremap <silent> <Plug>VinegarVerticalSplitUp :call <SID>opendir('vsplit')<CR>
 


### PR DESCRIPTION
In addition to opening netrw in the current buffer or a new split, it should be possible to open it up in a new tab.
