### PR TITLE
Respect existing setting for g:netrw_banner

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -21,7 +21,9 @@ let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
 let g:netrw_list_hide =
       \ join(map(split(&wildignore, ','), '"^".' . s:escape . '. "$"'), ',') . ',^\.\.\=/\=$' .
       \ (get(g:, 'netrw_list_hide', '')[-strlen(s:dotfiles)-1:-1] ==# s:dotfiles ? ','.s:dotfiles : '')
-let g:netrw_banner = 0
+if !exists("g:netrw_banner")
+  let g:netrw_banner = 0
+endif
 let s:netrw_up = ''
 
 nnoremap <silent> <Plug>VinegarUp :call <SID>opendir('edit')<CR>


### PR DESCRIPTION
Changes behavior to make the banner hidden by default, but still allows the user to make it unhidden through their vimrc.

My own use case:

I keep the banner in my netrw shown, but folded by putting this in ~/.vim/after/ftplugin/netrw.vim:

    setlocal foldmethod=expr foldexpr=getline(v:lnum)=~'^\"' foldlevel=0

Vinegar broke this.