### PR TITLE
make vinegar work in wide mode g:netrw_liststyle=2

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -55,7 +55,11 @@ function! s:opendir(cmd)
 endfunction
 
 function! s:seek(file)
-  let pattern = '^\%(| \)*'.escape(a:file, '.*[]~\').'[/*|@=]\=\%($\|\t\)'
+  if get(b:, 'netrw_liststyle') == 2
+    let pattern = '\%(^\|\s\+\)\zs'.escape(a:file, '.*[]~\').'[/*|@=]\=\%($\|\s\+\)'
+  else
+    let pattern = '^\%(| \)*'.escape(a:file, '.*[]~\').'[/*|@=]\=\%($\|\t\)'
+  endif
   call search(pattern, 'wc')
   return pattern
 endfunction


### PR DESCRIPTION
In wide mode a file name does not necessarily begin on the beginning of a line neither  end on the end of a line.
instead check for leading/trailing spaces.

Might have side effects in directories with lots of spaces in file names and therefore the pattern is only applied in that g:netrw_liststyle.