### PR TITLE
File hiding supports g:netrw_liststyle

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -18,8 +18,10 @@ let s:dotfiles = '\(^\|\s\s\)\zs\.\S\+'
 
 let g:netrw_sort_sequence = '[\/]$,*,\%(' . join(map(split(&suffixes, ','), 'escape(v:val, ".*$~")'), '\|') . '\)[*@]\=$'
 let s:escape = 'substitute(escape(v:val, ".$~"), "*", ".*", "g")'
+let s:bol = '"\\(^\\|\\s\\)".'
+let s:eol = '."\\($\\|\\s\\)"'
 let g:netrw_list_hide =
-      \ join(map(split(&wildignore, ','), '"^".' . s:escape . '. "$"'), ',') . ',^\.\.\=/\=$' .
+      \ join(map(split(&wildignore, ','), s:bol . s:escape . s:eol), ',') . ',^\.\.\=/\=$' .
       \ (get(g:, 'netrw_list_hide', '')[-strlen(s:dotfiles)-1:-1] ==# s:dotfiles ? ','.s:dotfiles : '')
 if !exists("g:netrw_banner")
   let g:netrw_banner = 0


### PR DESCRIPTION
Long and wide listings may display more than a filename per line.
With this new regex, file hiding works with this kind of listing too.

Closes #49