### PR TITLE
Clarify default behavior of dotfile hiding

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,13 @@ to even consider.
 * All that annoying crap at the top is turned off, leaving you with nothing
   but a list of files.  This is surprisingly disorienting, but ultimately
   very liberating.  Press `I` to toggle until you adapt.
-* The oddly C-biased default sort order and file hiding is replaced with a
-  sensible application of `'suffixes'` and `'wildignore'`.
+* The oddly C-biased default sort order is replaced with a sensible application
+  of `'suffixes'`.
+* File hiding: files are not listed that match with one of the patterns in
+  `'wildignore'`.  
+  If you put `let g:netrw_list_hide = '\(^\|\s\s\)\zs\.\S\+'`
+  in your vimrc, vinegar will initialize with dot files hidden.
+  Press `gh` to toggle dot file hiding.
 * Press `.` on a file to pre-populate it at the end of a `:` command line.
   This is great, for example, to quickly initiate a `:grep` of the file or
   directory under the cursor.  There's also `!`, which starts the line off


### PR DESCRIPTION
The buried comment https://github.com/tpope/vim-vinegar/issues/18#issuecomment-38975485
should be added to the README.markdown.