### PR TITLE
Fix error on windows 'Illegal filename' on line 13

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -46,7 +46,7 @@ function! s:opendir(cmd)
     if empty(expand('%'))
       execute a:cmd '.'
     else
-      execute a:cmd '%:h/'
+      execute a:cmd '%:h'
       call s:seek(expand('#:t'))
     endif
   endif


### PR DESCRIPTION
Tested on Windows 7 and Linux (Debian, Ubuntu).
