### PR TITLE
Handle the new netrw <Plug>-based mapping if present

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -98,11 +98,16 @@ endfunction
 function! s:setup_vinegar() abort
   if empty(s:netrw_up)
     " save netrw mapping
-    let s:netrw_up = substitute(maparg('-', 'n'), '\c^:\%(<c-u>\)\=', '', '')
-    " saved string is like this:
-    " :exe "norm! 0"|call netrw#LocalBrowseCheck(<SNR>172_NetrwBrowseChgDir(1,'../'))<CR>
-    " remove <CR> at the end (otherwise raises "E488: Trailing characters")
-    let s:netrw_up = strpart(s:netrw_up, 0, strlen(s:netrw_up)-4)
+    let s:netrw_up = maparg('-', 'n')
+    if s:netrw_up =~? "^<Plug>"
+      let s:netrw_up = "execute \"normal \\".s:netrw_up."\""
+    else
+      " saved string is like this:
+      " :exe "norm! 0"|call netrw#LocalBrowseCheck(<SNR>172_NetrwBrowseChgDir(1,'../'))<CR>
+      let s:netrw_up = substitute(s:netrw_up, '\c^:\%(<c-u>\)\=', '', '')
+      " remove <CR> at the end (otherwise raises "E488: Trailing characters")
+      let s:netrw_up = strpart(s:netrw_up, 0, strlen(s:netrw_up)-4)
+    endif
   endif
   nmap <buffer> - <Plug>VinegarUp
   cnoremap <buffer><expr> <Plug><cfile> get(<SID>relatives('.'),0,"\022\006")


### PR DESCRIPTION
I had a quick try at fixing #87... it seems to work, but (particularly the double-`execute`) doesn't feel particularly elegant.

It's really just a variation on https://github.com/tpope/vim-vinegar/issues/87#issuecomment-343347094, but sticks more closely to re-using the existing `-` mapping, and avoids an explicit version check.

(I haven't confirmed this still works with older netrw, though it seems likely.)