### PR TITLE
Remove prefix of tree view items on command

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -75,6 +75,7 @@ endfunction
 function! s:absolutes(first, ...) abort
   let files = getline(a:first, a:0 ? a:1 : a:first)
   call filter(files, 'v:val !~# "^\" "')
+  call map(files, "substitute(v:val, '^\\(| \\)*', '', '')")
   call map(files, 'b:netrw_curdir . s:slash() . substitute(v:val, "[/*|@=]\\=\\%(\\t.*\\)\\=$", "", "")')
   return files
 endfunction


### PR DESCRIPTION
In order for the . , ! or y commands to work the intended way, the
leading '| ' will be now stripped when executing one of the above
commands.

There is the known limitation that this will not work with folders/files
starting with '| ' as this was considered an edge case and too
complicated for this easy fix.

Fix for #85 