### PR TITLE
Allow VinegarUp to work correctly with remote URLs

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -48,7 +48,7 @@ function! s:opendir(cmd) abort
   elseif expand('%') =~# '^$\|^term:[\/][\/]'
     execute a:cmd '.'
   else
-    execute a:cmd '%:h'
+    execute a:cmd '%:h' . s:slash()
     call s:seek(expand('#:t'))
   endif
 endfunction


### PR DESCRIPTION
Fix for bug #111.  Originally, this was fixed by #34, but was reverted due to an issue on windows (#75).

I have tested this fix on Windows 10 and macOS (terminal)