### PR TITLE
Don't save <Plug>VinegarUp as a prior netrw_up - map

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -113,7 +113,7 @@ endfunction
 function! s:setup_vinegar() abort
   if !exists('s:netrw_up')
     let orig = maparg('-', 'n')
-    if orig =~? '^<plug>'
+    if orig =~? '^<plug>' && orig !=# '<Plug>VinegarUp'
       let s:netrw_up = 'execute "normal \'.substitute(orig, ' *$', '', '').'"'
     elseif orig =~# '^:'
       " :exe "norm! 0"|call netrw#LocalBrowseCheck(<SNR>123_NetrwBrowseChgDir(1,'../'))<CR>


### PR DESCRIPTION
Occasionally I've run into this error when tapping `-`:

```
Error detected while processing function <SNR>42_opendir[7]..<SNR>42_opendir[7].. [etc.]
line    7:
E169: Command too recursive
Press ENTER or type command to continue
```

Today I tracked it down to only netrw buffers, and figured out that If a session saved with `ssop` `options` or `localoptions` has a netrw buffer shown, when that session is loaded you run into the above in that buffer.  When `s:setup_vinegar` autoruns, it saves its own <Plug>VinegarUp mapping into `s:netrw_up`, so there's an infinite recursion when opendir is called.

I'm not sure if this is the best fix, just a quick fix. 