### PR TITLE
Fix file name search after using VinegarUp (the - key).

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -54,8 +54,9 @@ function! s:opendir(cmd) abort
   elseif expand('%') =~# '^$\|^term:[\/][\/]'
     execute a:cmd '.'
   else
+    let currentFilename = expand('%:t')
     execute a:cmd '%:h' . (expand('%:p') =~# '^\a\a\+:' ? s:slash() : '')
-    call s:seek(expand('#:t'))
+    call s:seek(currentFilename)
   endif
 endfunction
 


### PR DESCRIPTION
Recently file search after opening netfw buffer does not work consistently. Sometimes pressing "-" opens the parent directory with the cursor on the first line instead of the current file line.

The actual problem is that the alternative buffer name is empty after going to the netrw buffer and `expand('#:t')` returns empty string.

This change fixes it by saving the current file name before opening the netrw buffer.

Note that underlying issue is not solved: the alternative buffer is still empty, so Ctrl-6 to go back to file from netrw still does not work. I did not try to research the problem with the alternative buffer.

Should be related to https://github.com/tpope/vim-vinegar/issues/136. The issue mentions "Vim >= 9.0", I have neovim 0.10.0 currently (not sure, but it might be possible that the problem appeared after upgrade to 0.10.0).